### PR TITLE
Utilize robotini file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ build all targets in the correct order.
 
 ## Requirements
 
-`rossum` is written in Python 2, so naturally it needs a Python 2 install.
+`rossum` is written in Python 3, so naturally it needs a Python 3 install. 'rossum.cmd' calls python launcher "py -3", so make sure python launcher is installed with your python 3 distribution.
 
 The generated Ninja build files require a recent (> 1.7.1) version of [Ninja][]
 to be present.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ optional arguments:
   -p, --pkg-dir         Additional paths to search for packages (multiple
                         allowed)
   -r, --robot-ini       Location of robot.ini (default: source dir)
+  -o, --override        Overrides path locations and version in robot.ini file.
+                        For example if the robot.ini file specifies V9.10-1 with
+                        V9.10-1 support files, use --override and --core ID V7.70-1
+                        to build for another robot controller version.
   -w, --overwrite       Overwrite any Makefile that may exist in the build dir
 
 Usage example:
@@ -104,7 +108,38 @@ Usage example:
   cd C:\foo\bar\build
   rossum C:\foo\bar\src
 ```
+## Robot.ini
 
+robot.ini file should be created using the `setrobot.exe` tool found in your
+roboguides bin directory (e.g. C:\Program Files (x86)\Fanuc\WinOLPC\bin).
+
+1. Navigate to winOLPC installation folder
+2. Delete any robot.ini files in folder
+3. Right click **Run as administrator**
+4. Select the robot Work Cell
+
+robot.ini file should be formatted as follows
+
+```
+[WinOLPC_Util]
+Robot=\C\Users\%USERNAME%\Documents\My Workcells\OlpcPRO1\Robot_1
+Version=V8.20-1
+Path=C:\Program Files (x86)\Fanuc\WinOLPC\Versions\V820-1\bin
+Support=C:\Users\%USERNAME%\Documents\My Workcells\OlpcPRO1\Robot_1\support
+Output=C:\Users\%USERNAME%\Documents\My Workcells\OlpcPRO1\Robot_1\output
+```
+
+If `Robot`, `Path`, or `Support` paths do not exist ktrans.exe and thus
+ktransw will fail. Ensure that paths specified exist and are accurate.
+
+You can override these paths by including the -o, --override argument and
+specifying your own version with the --core argument or the
+ROSSUM_CORE_VERSION environment variable. This will build the ninja file 
+with the specified version and use the support files of that version.
+
+Note: robot.ini file is still needed and will be used by `ktrans.exe`.Therefore
+accurate paths are needed in the robot.ini file even if they are not used by
+ktransw.
 
 ## Environment variables
 

--- a/rossum.cmd
+++ b/rossum.cmd
@@ -14,4 +14,4 @@ REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 REM See the License for the specific language governing permissions and
 REM limitations under the License.
 REM
-python "%~dp0\rossum.py" %*
+py -3 "%~dp0\rossum.py" %*

--- a/rossum.py
+++ b/rossum.py
@@ -441,11 +441,15 @@ def main():
     #
     # Template processing
     #
+    if isversion(robot_ini_info.version) and not args.override_ini:
+        ktrans_version = robot_ini_info.version
+    else:
+        ktrans_version = args.core_version
 
     # populate dicts & lists needed by template
     ktrans = KtransInfo(path=ktrans_path, support=KtransSupportDirInfo(
         path=fr_support_dir,
-        version_string=args.core_version))
+        version_string=ktrans_version))
     ktransw = KtransWInfo(path=ktransw_path)
     bs_info = RossumSpaceInfo(path=build_dir)
     sp_infos = [RossumSpaceInfo(path=p) for p in src_space_dirs]

--- a/rossum.py
+++ b/rossum.py
@@ -19,7 +19,7 @@
 # rossum - a 'cmake for Fanuc Karel'
 #
 # Prerequisites:
-#  - Python 2.7.x
+#  - Python > 3.4.x
 #  - ninja build system (https://ninja-build.org)
 #  - EmPy
 #


### PR DESCRIPTION
Issue with running rossum for multiple robot controller version, where                                                                                                         robot.ini file was not being taken into account. Environment variable                                                                                                            for version was not efficient if running for multiple controller                                                                                                                 versions. Problem still arises for building same package for multiple                                                                                                             controller with different versions, but an override argument is added to be able to                                                                                                               control this with rossum options. I am currently just having multiple
robot.ini files for each controller and specifying them with -r ../path/to/robot.ini
during build.