### PR TITLE
upload files in build directory to robot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode/settings.json

--- a/ftp.txt.em
+++ b/ftp.txt.em
@@ -1,4 +1,4 @@
-open @(ip)
+open @(ws.robot_ini.ftp)
 anon
 bin
 prompt
@@ -7,7 +7,7 @@ mdel @
 @[for pkg in ws.pkgs]@
 @[if len(pkg.objects) > 0]@
 @[for (src, obj) in pkg.objects]@
-"@(ws.build.path)\@(obj)" @
+"@(obj)" @
 @[end for]@
 @[end if]@
 @[end for]@
@@ -18,7 +18,7 @@ mdel @
 @[if len(pkg.objects) > 0]@
 @[for (src, obj) in pkg.objects]@
 @[if '.pc' in obj]@
-"@(ws.build.path)\@(os.path.splitext(obj)[0]+'.vr')" @
+"@(os.path.splitext(obj)[0]+'.vr')" @
 @[end if]@
 @[end for]@
 @[end if]@

--- a/ftp.txt.em
+++ b/ftp.txt.em
@@ -2,6 +2,29 @@ open @(ip)
 anon
 bin
 prompt
+@# delete all files that might be on controller
+mdel @
+@[for pkg in ws.pkgs]@
+@[if len(pkg.objects) > 0]@
+@[for (src, obj) in pkg.objects]@
+"@(ws.build.path)\@(obj)" @
+@[end for]@
+@[end if]@
+@[end for]@
+@# delete .vr files for .pc files of build
+@{import os}
+mdel @
+@[for pkg in ws.pkgs]@
+@[if len(pkg.objects) > 0]@
+@[for (src, obj) in pkg.objects]@
+@[if '.pc' in obj]@
+"@(ws.build.path)\@(os.path.splitext(obj)[0]+'.vr')" @
+@[end if]@
+@[end for]@
+@[end if]@
+@[end for]@
+
+@# put all objects of build onto controller
 mput @
 @[for pkg in ws.pkgs]@
 @[if len(pkg.objects) > 0]@

--- a/ftp.txt.em
+++ b/ftp.txt.em
@@ -1,0 +1,14 @@
+open @(ip)
+anon
+bin
+prompt
+mput @
+@[for pkg in ws.pkgs]@
+@[if len(pkg.objects) > 0]@
+@[for (src, obj) in pkg.objects]@
+"@(ws.build.path)\@(obj)" @
+@[end for]@
+@[end if]@
+@[end for]@
+
+quit

--- a/kpush.cmd
+++ b/kpush.cmd
@@ -1,0 +1,2 @@
+@echo off
+ftp -s:ftp.txt


### PR DESCRIPTION
- use empy to make template for ftp upload
- server ip is set with environment variable, ROSSUM_SERVER_IP, or argument --ftp.
- split empy interpreter for ninja, and ftp up, however use the same globals.
- streamline ftp upload into command 'kpush'. *** This will only work if the working directory is the build directory.